### PR TITLE
cull superfluous peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,6 @@
     "test": "standard && tape test/*.js | tap-spec"
   },
   "peerDependencies": {
-    "eslint": "^1.0.0",
-    "eslint-config-standard": "^4.0.0",
-    "eslint-plugin-standard": "^1.2.0"
+    "eslint-config-standard": "^4.0.0"
   }
 }


### PR DESCRIPTION
- as discussed over in #7  ...

- reduce peerDeps down to just eslint-config-standard (bare essentials)

    - no need to specify peerDeps that are already specified as peerDeps by eslint-config-standard