### PR TITLE
README Install Instructions Correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ eslint sharable config for semistandard
 ## Install
 
 ```bash
-npm install eslint-config-semistandard
-npm install eslint-config-semistandard eslint-plugin-react
-# note that eslint-plugin-react is required
+npm install eslint-plugin-promise eslint-plugin-standard eslint-plugin-react
+npm install eslint-config-standard@5.1.0 
+npm install eslint-config-semistandard 
+# note that eslint-plugin-promise, eslint-plugin-standard, & eslint-plugin-react are required peer dependencies
 ```
 
 ## Usage


### PR DESCRIPTION
In the install directions here in the README, it says to install eslint-config-semistandard twice. 

I'm pretty sure the first line was supposed to be eslint-config-standard since it gets marked as an UNMET PEER DEPENDENCY by npm 3.

There are also 2 unmet peer dependencies for the standard config (its plugin and the promise plugin), which I included with the eslint-plugin-react you already had listed.

Additionally, the specific version eslint-config-standard@5.1.0 was being asked for, so I tacked that on. I think you will be fixing that soon though based on what I read in the open issue.

Thanks,
-Josh