### PR TITLE
Moving devDependencies to dependencies to avoid issues with npm3 & yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "bugs": {
     "url": "https://github.com/Flet/eslint-config-semistandard/issues"
   },
+  "dependencies": {
+    "eslint": "^3.4.0",
+    "eslint-config-standard": "^6.0.0",
+    "eslint-plugin-standard": "^2.0.0",
+    "standard": "^8.0.0"
+  },
   "devDependencies": {
     "tap-spec": "^4.0.0",
     "tape": "^4.6.0"
@@ -49,12 +55,5 @@
   },
   "peerDependencies": {
     "eslint-config-standard": "^6.0.0"
-  },
-  "dependencies": {
-    "eslint": "~3.8.1",
-    "eslint-config-standard": "~6.2.0",
-    "eslint-plugin-promise": "~3.3.0",
-    "eslint-plugin-standard": "~2.0.1",
-    "standard": "~8.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,10 +7,6 @@
     "url": "https://github.com/Flet/eslint-config-semistandard/issues"
   },
   "devDependencies": {
-    "eslint": "^3.4.0",
-    "eslint-config-standard": "^6.0.0",
-    "eslint-plugin-standard": "^2.0.0",
-    "standard": "^8.0.0",
     "tap-spec": "^4.0.0",
     "tape": "^4.6.0"
   },
@@ -53,5 +49,12 @@
   },
   "peerDependencies": {
     "eslint-config-standard": "^6.0.0"
+  },
+  "dependencies": {
+    "eslint": "~3.8.1",
+    "eslint-config-standard": "~6.2.0",
+    "eslint-plugin-promise": "~3.3.0",
+    "eslint-plugin-standard": "~2.0.1",
+    "standard": "~8.4.0"
   }
 }


### PR DESCRIPTION
Moving devDependencies to dependencies to avoid issues with npm 3 & yarn

I am encountering issues with `eslint-config-standard` from `peerDependencies` since **npm3** and **yarn** don't support  `peerDependencies` and its currently located in `devDependencies` it never gets installed in `node_modules`