### PR TITLE
Update deps to match eslint-config-standard 12

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - '4'
   - '6'
+  - '8'
   - 'node'
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
     "url": "https://github.com/Flet/eslint-config-semistandard/issues"
   },
   "devDependencies": {
-    "eslint": "^4.18.0",
-    "eslint-config-standard": "^11.0.0",
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-node": "^5.2.1",
-    "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-react": "^7.5.1",
-    "eslint-plugin-standard": "^3.0.1",
-    "standard": "^11.0.0-beta.0",
-    "tap-spec": "^4.1.1",
-    "tape": "^4.8.0"
+    "eslint": "^5.4.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-promise": "^4.0.0",
+    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-standard": "^4.0.0",
+    "standard": "^12.0.1",
+    "tap-spec": "^5.0.0",
+    "tape": "^4.9.1"
   },
   "homepage": "https://github.com/Flet/eslint-config-semistandard",
   "keywords": [
@@ -49,12 +49,12 @@
   "license": "ISC",
   "main": "index.js",
   "peerDependencies": {
-    "eslint": ">=4.18.0",
-    "eslint-config-standard": "^11.0.0",
-    "eslint-plugin-import": ">=2.8.0",
-    "eslint-plugin-node": ">=5.2.1",
-    "eslint-plugin-promise": ">=3.6.0",
-    "eslint-plugin-standard": ">=3.0.1"
+    "eslint": ">=5.4.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": ">=2.14.0",
+    "eslint-plugin-node": ">=7.0.1",
+    "eslint-plugin-promise": ">=4.0.0",
+    "eslint-plugin-standard": ">=4.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Changes:**
- bumping dev & peer dependencies versions
- adding `.npmrc` to prevent package lock creation