### PR TITLE
specify `eslint-plugin-n@^16.0.0` as valid peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eslint": "^8.13.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-n": "^15.2.4",
+    "eslint-plugin-n": "^16.6.1",
     "eslint-plugin-promise": "^6.0.0",
     "tape": "^5.5.3"
   },
@@ -52,7 +52,7 @@
     "eslint": "^8.13.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-n": "^15.2.4",
+    "eslint-plugin-n": "^15.0.0 || ^16.0.0",
     "eslint-plugin-promise": "^6.0.0"
   },
   "repository": {


### PR DESCRIPTION
Renovate cannot update `eslint-plugin-n` in my NPM projects to v16 because `eslint-config-semistandard` does not see it as a valid peer dependency:

- https://github.com/AprilSylph/XKit-Rewritten/pull/1298#issuecomment-1741941410
- https://github.com/AprilSylph/Palettes-for-Tumblr/pull/157#issuecomment-1571155121
- https://github.com/AprilSylph/Outbox-for-Tumblr/pull/70#issuecomment-1571188535

Since `eslint-config-semistandard` does not directly make use of `eslint-plugin-n`, but rather inherits the usage from `eslint-plugin-standard`, this PR proposes to bump the peer dependency version range for `eslint-plugin-n` to [match that of `eslint-plugin-standard@17.1.0`](https://github.com/standard/eslint-config-standard/blob/v17.1.0/package.json#L57).

(Interesting that dependabot isn't trying to perform this major upgrade...)